### PR TITLE
fix addEffectsCount

### DIFF
--- a/Examples/NeoEfx_Subclass/NeoEfx_Subclass.ino
+++ b/Examples/NeoEfx_Subclass/NeoEfx_Subclass.ino
@@ -4,11 +4,11 @@
 */
 
 #include <Adafruit_NeoPixel.h>
-#include <NeoEffects.h>
+#include "NeoEffects.h"
 #include "NeoRainbowEfx.h"
 
 //////////////////////////////////////////
-#define SMALL_NEORING_SIZE 12
+#define SMALL_NEORING_SIZE 16
 
 #define STRIP_1_PIN 2
 
@@ -42,7 +42,7 @@ void setup() {
   Serial.begin(115200);
   delay(500); // delay a bit when we start so we can open arduino serial monitor window
   
-  Serial.println("Starting NeoEffects Example2");
+  Serial.println("Starting NeoEffects Subclass Rainbow Example");
 
   // start the strip.  do this first for all strips
   strip1.begin();
@@ -55,18 +55,53 @@ void setup() {
   blinkWholeStrip();
 
   ring1.setWipeEfx(strip1.randomColor(),100 ); // wipe on a random color
-  ring2.setRainbowEfx( 100 );
+  ring2.setRainbowEfx( 100, 0 );
 
 }
 
+int stateOne = 0;  // update to change ring1 effects
+int stateTwo = 0;
 
 void loop() {
   // grab the current time in class method
   NeoWindow::updateTime();
 
   // Simple wipe completed? chose another random color
-  if (ring1.effectDone())
-    ring1.setWipeEfx(strip1.randomColor(),100 );
+  if (ring1.effectDone()) {
+    stateOne++;
+    switch (stateOne) {
+      case 1:
+        Serial.println("Ring1 Sparkle");
+        ring1.setSparkleEfx(strip1.randomColor(),  50,  50, 100);
+        break;
+      case 2:
+        Serial.println("Ring1 Fade");
+        ring1.setFadeEfx(0, strip1.randomColor(), 100, ring1.fadeTypeCycle, 0); // fade between two colors
+        break;
+      case 3:
+        Serial.println("Ring1 Circle");
+        ring1.setCircleEfx(strip1.randomColor(), 200);
+        break;
+     default:
+        Serial.println("Ring1 WipeEfx");
+        stateOne = 0;
+        ring1.setWipeEfx(strip1.randomColor(),100 );
+    }
+  }
+  if (ring2.effectDone()) {
+    if (stateTwo == 0) { 
+      ring2.setRainbowEfx( 100, 1 );
+      stateTwo = 1;
+    } else {
+      ring2.setRainbowEfx( 100, 0 );
+      stateTwo = 0;
+    }
+  Serial.print("Rainbow State ");Serial.println(stateTwo);
+  }
+  
+  if (ring2.getEffectCount() > 10) {
+    ring2.setRainbowEfx( 100, 1 );
+  }
 
     // now update each Window - does one 'frame' of effect on the window
   ring1.updateWindow();

--- a/Examples/NeoEfx_Subclass/NeoRainbowEfx.cpp
+++ b/Examples/NeoEfx_Subclass/NeoRainbowEfx.cpp
@@ -1,5 +1,7 @@
 // NeoRainbowEfx - a subclass of NeoWindow to add rainbow efx
 // effect is taken from the Adafruit_NeoPixel Library's strandtest example
+// type 0 = window shows myPixelCount portion of wheel each update, thru all 255 colors
+// type 1 = evenly distributes wheel across N pixels in window (full rainbow in window)
 
 #include "NeoRainbowEfx.h"
 
@@ -9,29 +11,37 @@ NeoRainbowEfx::NeoRainbowEfx(NeoStrip *strip, int startPixel, int len)
   
 }
 
-void NeoRainbowEfx:: setRainbowEfx(uint16_t waitTime)
+void NeoRainbowEfx:: setRainbowEfx(uint16_t waitTime, int type)
 {
   // members common to all effects
-  efxDone = false;
+  setNoEfx();// reset counters
   effectDelay = waitTime;
   // effect specfic members
   curColor = 0;
+  rainbowType = type;
+
   // and set the update function - magic of function poiners
   curUpdateFunc = (NeoWindowUpdateFunc) &NeoRainbowEfx::rainbowEfxUpdate;
 }
 
 void NeoRainbowEfx::rainbowEfxUpdate(void)
 {
-  for (int i=myStartPixel; i <= myEndPixel; i++)
+  // put a color in each pixel of window, depending on type
+  for (int i=0; i <= myPixelCount; i++)
   {
-      // colorWheel has 255 colors, from Adafruit NeoPixel strandtest example
-      myStrip->setPixelColor(i, NeoStrip::colorWheel((i+curColor) & 255));
+    // colorWheel has 255 colors, from Adafruit NeoPixel strandtest example
+    if (rainbowType == 0) {
+      myStrip->setPixelColor(i+myStartPixel, NeoStrip::colorWheel((i+curColor) & 255));
+    } else {
+      myStrip->setPixelColor(i+myStartPixel, NeoStrip::colorWheel(((i*256/myPixelCount)+curColor) & 255));
+    }
   }
 
   curColor++;
   if (curColor > 255)
   {
     // reached end of colors, mark effect done
+    effectCount++;
     efxDone = true;
     // and set color index back to start so we can keep cycling
     curColor = 0;

--- a/Examples/NeoEfx_Subclass/NeoRainbowEfx.h
+++ b/Examples/NeoEfx_Subclass/NeoRainbowEfx.h
@@ -8,9 +8,12 @@ class NeoRainbowEfx : public NeoWindow
   public:
     NeoRainbowEfx(NeoStrip *strip, int startPixel, int len);
 
-  void setRainbowEfx(uint16_t wait);
+  void setRainbowEfx(uint16_t wait, int type); // type 0 or 1; 1 evenly distributes color
+  void setRainbowCycleEfx(uint16_t wait);
 private:
   void rainbowEfxUpdate(void);
+  void rainbowCycleEfxUpdate(void);
   int curColor;
+  int rainbowType;
 };
 

--- a/NeoWindow.h
+++ b/NeoWindow.h
@@ -10,7 +10,7 @@
 #include <AdaFruit_NeoPixel.h>
 
 // and our NeoStrip object that encapsulates the Pixel
-#include <NeoStrip.h>
+#include "NeoStrip.h"
 
 class NeoWindow 
 {
@@ -34,6 +34,7 @@ public:
 
   void updateWindow(void); // invoke the current effect function
   boolean effectDone(void) {return efxDone;}
+  int getEffectCount(void) {return effectCount;}
   
   void printId(void);
   void printData(void);
@@ -56,6 +57,7 @@ protected:
   uint16_t myEndPixel;    // absolute index of last pixel in this window
 
   boolean efxDone;  // set when current effect is complete, if ever
+  uint16_t effectCount;
 
   uint32_t lastTime; // the last time current effect updated
   uint32_t effectDelay; // delay between updates of current effect
@@ -75,7 +77,7 @@ protected:
 //  void setRainbowEfx(uint32_t delayTime);
 
 public:
-  void setNoEfx();  // ignore this window
+  void setNoEfx();  // ignore this window, resets all counters, timers, etc
   void setHoldEfx(int delayTime); // hold current colors for delayTime
 private:
   void holdUpdateEfx(void);
@@ -108,7 +110,6 @@ private:
   uint32_t blink_color;
   boolean blink_state;
   int blink_maxCount;
-  int blink_step;
 
 public:
   void setSparkleEfx(uint32_t color, int flashTime, int tweenTime, int count = 0);
@@ -118,7 +119,6 @@ private:
   int sparkleFlashTime;
   int sparkleTweenTime;
   int sparkleMaxCount;
-  int sparkleCount;
   int sparkleCurPixel;
   int sparkleState;
 
@@ -131,7 +131,6 @@ private:
   int multiSparkleFlashTime;
   int multiSparkleTweenTime;
   int multiSparkleMaxCount;
-  int multiSparkleCount;
   int multiSparkleNumActive;
   int multiSparkleState;
 
@@ -149,7 +148,6 @@ private:
   
   int fadeType;
   int fadeMaxCount;
-  int fadeCount;
   // internally we use seperate RGB values
   int fadeFromR;
   int fadeFromG;


### PR DESCRIPTION
added effectsCount.. which meant I had to touch all the effects and
remove their particular Count vars
Also put reset/setup of timer/count into SetNoEfx() and use it in start
of all Set…Efx().
While doing this I found the RainbowEfx subclass was a bit lacking.  It
only implemented one of three types in strand test example… The evenly
distributed version was not implemented, but useful.  So I put in two
RainbowTypes.
And then implemented a state machine for the two rings/windows in the
Subclass example app.
